### PR TITLE
bugfix: ThreadPool.Terminate() does not wait for threads to finish

### DIFF
--- a/pool/thread.go
+++ b/pool/thread.go
@@ -24,11 +24,13 @@
 package pool
 
 import (
-	"fmt"
+	"errors"
 	"sync"
 
 	"github.com/karalabe/iris/container/queue"
 )
+
+var ErrTerminating = errors.New("pool terminating")
 
 // A task function meant to be started as a go routine.
 type Task func()
@@ -36,108 +38,115 @@ type Task func()
 // A thread pool to place a hard limit on the number of go-routines doing some
 // type of (possibly too consuming) work.
 type ThreadPool struct {
-	mutex  sync.Mutex
-	seed   bool
-	task   chan Task
-	worker chan struct{}
-	clear  chan struct{}
-	quit   chan struct{}
+	mutex sync.Mutex
+	tasks *queue.Queue
+
+	start bool
+	idle  int
+	total int
+
+	quit bool
+	done *sync.Cond
 }
 
 // Creates a thread pool with the given concurrent thread capacity.
-func NewThreadPool(capacity int) *ThreadPool {
-	p := &ThreadPool{
-		task:   make(chan Task),
-		worker: make(chan struct{}, capacity),
-		clear:  make(chan struct{}),
-		quit:   make(chan struct{}),
+func NewThreadPool(cap int) *ThreadPool {
+	t := &ThreadPool{
+		tasks: queue.New(),
+		idle:  cap,
+		total: cap,
 	}
-	go p.loop()
-	return p
-}
-
-func (t *ThreadPool) loop() {
-	var next Task
-	tasks := queue.New()
-	worker := t.worker
-	// wait for work or signals
-	for {
-		// get the next task if we need one and it's available
-		if next == nil && !tasks.Empty() {
-			next = tasks.Pop().(Task)
-		}
-		if next == nil {
-			worker = nil // disable receiving a worker since we don't have a task
-		} else {
-			worker = t.worker // enable receiving a worker since we do have a task
-		}
-		select {
-		case task := <-t.task:
-			tasks.Push(task)
-		case <-worker:
-			task := next
-			go func() {
-				task()
-				t.worker <- struct{}{}
-			}()
-			next = nil
-		case <-t.clear:
-			tasks.Reset()
-			next = nil
-		case <-t.quit:
-			return
-		}
-	}
+	t.done = sync.NewCond(&t.mutex)
+	return t
 }
 
 // Starts the thread pool and workers.
 func (t *ThreadPool) Start() {
 	t.mutex.Lock()
-	if !t.seed {
-		// seed with workers
-		for i := 0; i < cap(t.worker); i++ {
-			t.worker <- struct{}{}
+	defer t.mutex.Unlock()
+
+	if !t.start {
+		for i := 0; i < t.total && !t.tasks.Empty(); i++ {
+			t.idle--
+			go t.runner(t.tasks.Pop().(Task))
 		}
-		t.seed = true
+		t.start = true
 	}
-	t.mutex.Unlock()
 }
 
 // Waits for all threads to finish, terminating the whole pool afterwards. No
 // new tasks are accepted in the meanwhile.
 func (t *ThreadPool) Terminate() {
 	t.mutex.Lock()
-	select {
-	case <-t.quit:
-		// closed
-	default:
-		// close and wait for all work to complete
-		close(t.quit)
-		if t.seed {
-			for i := 0; i < cap(t.worker); i++ {
-				<-t.worker
-			}
-		}
+	defer t.mutex.Unlock()
+
+	t.quit = true
+	t.tasks.Reset()
+
+	for t.idle < t.total {
+		t.done.Wait()
 	}
-	t.mutex.Unlock()
 }
 
 // Schedules a new task into the thread pool.
 func (t *ThreadPool) Schedule(task Task) error {
-	select {
-	case t.task <- task:
-		return nil
-	case <-t.quit:
-		return fmt.Errorf("pool terminating")
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+
+	// If terminating, return so
+	if t.quit {
+		return ErrTerminating
 	}
+
+	if t.start && t.idle > 0 {
+		t.idle--
+		go t.runner(task)
+	} else {
+		t.tasks.Push(task)
+	}
+
+	return nil
 }
 
 // Dumps the waiting tasks from the pool.
 func (t *ThreadPool) Clear() {
-	select {
-	case t.clear <- struct{}{}:
-		// cleared
-	case <-t.quit:
-		// closed
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+
+	t.tasks.Reset()
+}
+
+func (t *ThreadPool) runner(task Task) {
+	// Make sure the idle count is incremented back even if we panic
+	defer func() {
+		t.mutex.Lock()
+		// Without this respawn hack there's a race condition where a task
+		// may be scheduled after a runner has exited its loop but before it's
+		// gotten here to be marked as idle. Do one last check for that case
+		// while we have the lock.
+		if t.tasks.Empty() {
+			t.idle++
+		} else {
+			go t.runner(t.tasks.Pop().(Task))
+		}
+		t.mutex.Unlock()
+
+		t.done.Signal()
+	}()
+
+	// Execute all tasks that are available
+	for ; task != nil; task = t.next() {
+		task()
 	}
+}
+
+func (t *ThreadPool) next() Task {
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+
+	if t.tasks.Empty() { // tasks reset on termination
+		return nil
+	}
+
+	return t.tasks.Pop().(Task)
 }


### PR DESCRIPTION
Your project looks very interesting so I thought I'd grab a bug and help out :)

This should be a drop-in fix/replacement. All the previous tests pass and I added some extras. I did have to comment out a few lines from the previous test because it was accessing the (private) task queue which isn't accessible anymore (even from within the package).

I added some extra stuff in there too to prevent bad things from happening if Start or Terminate are called multiple times.

It's getting late here, so I'm gonna go crash but I can provide some other details later if you'd like.
