### PR TITLE
ThreadPool Broadcast instead of Signal

### DIFF
--- a/pool/thread.go
+++ b/pool/thread.go
@@ -131,7 +131,7 @@ func (t *ThreadPool) runner(task Task) {
 		}
 		t.mutex.Unlock()
 
-		t.done.Signal()
+		t.done.Broadcast()
 	}()
 	// Execute all tasks that are available
 	for ; task != nil; task = t.next() {


### PR DESCRIPTION
In the event that Terminate is called multiple times on a ThreadPool before all tasks have been completed, Signal will only wake one of them and the extras will wait forever. It may be a misuse of the API to call Terminate multiple times but Broadcast will prevent this behavior.
